### PR TITLE
Fixed javadocs warnings and errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,8 @@
         <connection>scm:git:git://github.com/bxfsh/boxfish-commons-web-model.git</connection>
         <developerConnection>scm:git:git://github.com/bxfsh/boxfish-commons-web-model.git</developerConnection>
         <url>http://github.com/bxfsh/boxfish-commons-web-model/tree/master/</url>
-      <tag>boxfish-commons-web-model-1.0.1</tag>
-  </scm>
+      	<tag>boxfish-commons-web-model-1.0.1</tag>
+  	</scm>
   
     <distributionManagement>
         <snapshotRepository>
@@ -106,6 +106,34 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>3.0.1</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.10.4</version>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
             
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>

--- a/src/main/java/boxfish/commons/web/model/Model.java
+++ b/src/main/java/boxfish/commons/web/model/Model.java
@@ -89,6 +89,7 @@ public class Model implements Map<String, Object> {
      *
      * @param field that will be validated
      * @param validatorBuilder the validation rule. Do put lambdas here to use.
+     * @param <TValue> type of the value being validated.
      * @return self
      */
     public <TValue> Model rules(

--- a/src/main/java/boxfish/commons/web/model/Value.java
+++ b/src/main/java/boxfish/commons/web/model/Value.java
@@ -36,9 +36,8 @@ public class Value {
      * Presents the value as String.
      *
      * @return a string representing the value
-     * @throws Exception raised if the type conversion fails.
      */
-    public String asString() throws Exception {
+    public String asString() {
         return new ValueToString(value).parse();
     }
 
@@ -47,9 +46,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return a long representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Long asLong() throws Exception {
+    public Long asLong() {
         return new ValueToLong(value).parse();
     }
 
@@ -58,9 +56,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return an integer representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Integer asInteger() throws Exception {
+    public Integer asInteger() {
         return new ValueToInteger(value).parse();
     }
 
@@ -69,9 +66,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return a short representing the value
-     * @throws Exception raised if the type conversion fails.
      */
-    public Short asShort() throws Exception {
+    public Short asShort() {
         return new ValueToShort(value).parse();
     }
 
@@ -80,9 +76,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return a byte representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Byte asByte() throws Exception {
+    public Byte asByte() {
         return new ValueToByte(value).parse();
     }
 
@@ -90,9 +85,8 @@ public class Value {
      * Presents the value as Boolean.
      *
      * @return a boolean representing a value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Boolean asBoolean() throws Exception {
+    public Boolean asBoolean() {
         return new ValueToBoolean(value).parse();
     }
 
@@ -101,9 +95,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return a BigDecimal representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public BigDecimal asBigDecimal() throws Exception {
+    public BigDecimal asBigDecimal() {
         return new ValueToBigDecimal(value).parse();
     }
 
@@ -112,9 +105,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return a Float representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Float asFloat() throws Exception {
+    public Float asFloat() {
         return new ValueToFloat(value).parse();
     }
 
@@ -123,9 +115,8 @@ public class Value {
      * of Numeric types and numeric Strings.
      *
      * @return a Double representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Double asDouble() throws Exception {
+    public Double asDouble() {
         return new ValueToDouble(value).parse();
     }
 
@@ -133,9 +124,8 @@ public class Value {
      * Presents the value as Instant.
      *
      * @return an Instant representing the value.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Instant asInstant() throws Exception {
+    public Instant asInstant() {
         return new ValueToInstant(value).parse();
     }
 
@@ -145,9 +135,8 @@ public class Value {
      * structures.
      *
      * @return a Model representing the value when it's a complex object.
-     * @throws Exception raised if the type conversion fails.
      */
-    public Model asModel() throws Exception {
+    public Model asModel() {
         return new ValueToModel(value).parse();
     }
 
@@ -155,6 +144,7 @@ public class Value {
      * Presents the value as an item of an Enum.
      *
      * @param enumType the type of the Enum.
+     * @param <TEnum> the type of the enum that will be used as return value.
      * @return the value of the Enum that was parsed from the original value.
      */
     public <TEnum extends Enum<TEnum>> TEnum asEnum(final Class<TEnum> enumType) {
@@ -164,11 +154,9 @@ public class Value {
     /**
      * Presents the value as a List of a particular type.
      *
-     * @param clazz the type of the entry in the list.
-     * @return a List<Value> representing the value.
-     * @throws Exception raised if the type conversion fails.
+     * @return a List of {@link Value} representing the value.
      */
-    public List<Value> asList() throws Exception {
+    public List<Value> asList() {
         return new ValueToList(value).parse();
     }
 
@@ -182,7 +170,7 @@ public class Value {
     }
 
     /**
-     * Presents the Class<?> of the value, or
+     * Presents the Class of ? of the value, or
      * Object.class when the value is null.
      *
      * @return the class of the value.

--- a/src/main/java/boxfish/commons/web/model/converters/AbstractValueConverter.java
+++ b/src/main/java/boxfish/commons/web/model/converters/AbstractValueConverter.java
@@ -26,7 +26,6 @@ public abstract class AbstractValueConverter<TValue> {
      * specific TValue in all possible ways.
      * 
      * @return the original value converted or parsed into TValue.
-     * @throws Exception raised when it fails to convert or parse.
      */
     public abstract TValue parse();
 }

--- a/src/main/java/boxfish/commons/web/model/converters/ValueToEnum.java
+++ b/src/main/java/boxfish/commons/web/model/converters/ValueToEnum.java
@@ -5,6 +5,7 @@ package boxfish.commons.web.model.converters;
  * which aims to perform any possible casting or parsing in representing
  * the original value as such.
  *
+ * @param <TEnum> the type of the enumerator that will be used for parsing.
  * @author Hudson Mendes
  *
  */

--- a/src/main/java/boxfish/commons/web/model/validation/ConditionFactory.java
+++ b/src/main/java/boxfish/commons/web/model/validation/ConditionFactory.java
@@ -22,6 +22,7 @@ public class ConditionFactory {
      * defining the type of value that will be later tested.
      * 
      * @param valueClass the type fo the value that will be later checked.
+     * @param <TValue> The type of the value that will be checked.
      * @return the next state (check) of the condition builder.
      */
     public <TValue extends Object> ConditionCheck<TValue> forType(Class<TValue> valueClass) {


### PR DESCRIPTION
This PR fixes the Javadocs problems that were preventing them to be published.
It is also setup to publish the sources and the javadocs when `mvn clean deploy` is run.